### PR TITLE
Adjust to Autoconf-2.71

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -174,10 +174,10 @@ AC_FUNC_MALLOC
 AC_CHECK_FUNCS( \
   strcpy \
   strdup \
-  strchr \ 
-  strlen \ 
-  strcat \ 
-  strtok \ 
+  strchr \
+  strlen \
+  strcat \
+  strtok \
 )
 AC_CHECK_FUNCS([getopt_long])
 


### PR DESCRIPTION
Autoconf-2.71 miconverts:

    AC_CHECK_FUNCS( \
      strcpy \
      strdup \
      strchr \
      strlen \
      strcat \
      strtok \
    )

into:

    for ac_func in strcpy strdup strchr \ strlen \ strcat \ strtok \
    do :
      [...]
    done

According to Autoconf documentation, the AC_CHECK_FUNCS supports
new lines as tokenizers.

This patch works around this issue by not escaping the new lines.

<https://bugzilla.redhat.com/show_bug.cgi?id=1999491>
<https://savannah.gnu.org/support/index.php?110571>