### PR TITLE
pingd: support ping_socket_receive_buffer

### DIFF
--- a/man/pingd.conf.5.in
+++ b/man/pingd.conf.5.in
@@ -53,6 +53,11 @@ regularly sent out.  Default is 15000.
 Specify the alternate default port the pingd server should listen
 for requests off of.  Default is 9125.
 .TP
+.I ping_socket_receive_buffer bytecount
+Specify size of the socket receive buffer in bytes.  This may be
+necessary on larger clusters where the default buffer cannot hold
+all ping responses.  System default used if set to <= 0.
+.TP
 .I host string
 Specify a host the pingd daemon should regularly ping.  Can be
 specified as many times as necessary.

--- a/src/pingd/pingd_config.c
+++ b/src/pingd/pingd_config.c
@@ -76,6 +76,7 @@ _config_default(void)
   conf.config_file = PINGD_CONF_FILE;
   conf.ping_period = PINGD_PING_PERIOD_DEFAULT;
   conf.pingd_server_port = PINGD_SERVER_PORT_DEFAULT;
+  conf.ping_socket_receive_buffer = PINGD_PING_SOCKET_RECEIVE_BUFFER;
 
   if (!(conf.hosts = hostlist_create(NULL)))
     ERR_EXIT(("hostlist_create: %s", strerror(errno)));
@@ -189,6 +190,7 @@ _config_file_parse(void)
 {
   int ping_period_flag,
     pingd_server_port_flag,
+    ping_socket_receive_buffer_flag,
     host_flag;
 
   struct conffile_option options[] =
@@ -214,6 +216,17 @@ _config_file_parse(void)
         &(pingd_server_port_flag),
         &(conf.pingd_server_port),
         0,
+      },
+      {
+        "ping_socket_receive_buffer",
+        CONFFILE_OPTION_INT,
+        -1,
+        conffile_int,
+        1,
+        0,
+        &(ping_socket_receive_buffer_flag),
+        &(conf.ping_socket_receive_buffer),
+        0
       },
       {
 	"host",
@@ -486,6 +499,8 @@ pingd_config_setup(int argc, char **argv)
       fprintf(stderr, "conf.debug = %d\n", conf.debug);
       fprintf(stderr, "conf.ping_period = %d\n", conf.ping_period);
       fprintf(stderr, "conf.pingd_server_port = %d\n", conf.pingd_server_port);
+      fprintf(stderr, "conf.ping_socket_receive_buffer = %d\n",
+              conf.ping_socket_receive_buffer);
       hostlist_ranged_string(conf.hosts, 1024, hbuf);
       fprintf(stderr, "conf.hosts = %s\n", hbuf);
     }

--- a/src/pingd/pingd_config.h
+++ b/src/pingd/pingd_config.h
@@ -33,9 +33,10 @@
 
 #include "hostlist.h"
 
-#define PINGD_DEBUG_DEFAULT           0
-#define PINGD_PING_PERIOD_DEFAULT     15000
-#define PINGD_SERVER_PORT_DEFAULT     9125
+#define PINGD_DEBUG_DEFAULT              0
+#define PINGD_PING_PERIOD_DEFAULT        15000
+#define PINGD_SERVER_PORT_DEFAULT        9125
+#define PINGD_PING_SOCKET_RECEIVE_BUFFER 0
 
 struct pingd_config
 {
@@ -46,6 +47,7 @@ struct pingd_config
 
   int ping_period;
   int pingd_server_port;
+  int ping_socket_receive_buffer;
   hostlist_t hosts;
 };
 

--- a/src/pingd/pingd_loop.c
+++ b/src/pingd/pingd_loop.c
@@ -109,6 +109,16 @@ _fds_setup(void)
   if ((ping_fd = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP)) < 0)
     ERR_EXIT(("socket: %s", strerror(errno)));
 
+  if (conf.ping_socket_receive_buffer > 0)
+    {
+      if (setsockopt(ping_fd,
+                     SOL_SOCKET,
+                     SO_RCVBUF,
+                     &conf.ping_socket_receive_buffer,
+                     sizeof(conf.ping_socket_receive_buffer)) < 0)
+        ERR_EXIT(("setsockopt: %s", strerror(errno)));
+    }
+
   memset(&addr, '\0', sizeof(struct sockaddr_in));
   addr.sin_family = AF_INET;
   addr.sin_port = htons(0);


### PR DESCRIPTION
Problem: On some larger clusters the default socket buffer could be overwhelmed with ping responses.

Support a new ping_socket_receive_buffer config to increase the size of the buffer.